### PR TITLE
Http4s tweaks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,8 @@ crossScalaVersions := Seq("2.12.13", "2.13.5")
 
 libraryDependencies ++= Seq(
   // Depend on http4s, which will pull in cats and circe
-  "org.http4s"       %% "http4s-blaze-client"   % "0.21.22",
-  "org.http4s"       %% "http4s-blaze-server"   % "0.21.22",
+  "org.http4s"       %% "http4s-ember-client"   % "0.21.22",
+  "org.http4s"       %% "http4s-ember-server"   % "0.21.22",
   "org.http4s"       %% "http4s-circe"          % "0.21.22",
   "org.http4s"       %% "http4s-dsl"            % "0.21.22",
 

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ libraryDependencies ++= Seq(
 )
 
 // Ensure canceling `run` releases socket, no matter what
-fork in run := true
+run / fork := true
 
 // Better syntax for dealing with partially-applied types
 addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.3" cross CrossVersion.full)
@@ -28,12 +28,12 @@ addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.3" cross CrossVers
 addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1")
 
 // Server config
-guardrailTasks in Compile := List(
+Compile / guardrailTasks := List(
   ScalaServer(file("server.yaml"), pkg="example.server", framework="http4s"),
 )
 
 // Client config for tests
-guardrailTasks in Test := List(
+Test / guardrailTasks := List(
   ScalaClient(file("server.yaml"), pkg="example.client", framework="http4s"),
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ libraryDependencies ++= Seq(
 
   // ZIO and the interop library
   "dev.zio"          %% "zio"                   % "1.0.7",
-  "dev.zio"          %% "zio-interop-cats"      % "3.0.2.0",
+  "dev.zio"          %% "zio-interop-cats"      % "2.4.1.0",
 )
 
 // Ensure canceling `run` releases socket, no matter what

--- a/src/main/scala/httpServer/package.scala
+++ b/src/main/scala/httpServer/package.scala
@@ -28,7 +28,7 @@ package httpServer {
         import org.http4s._
         import org.http4s.dsl.io._
         import org.http4s.implicits._
-        import org.http4s.server.blaze.BlazeServerBuilder
+        import org.http4s.ember.server.EmberServerBuilder
 
         // Pardon the asInstanceOf, ioTimer has no way to inject R
         implicit val timer: Timer[RIO[R, *]] = ioTimer[R, Throwable]
@@ -36,10 +36,9 @@ package httpServer {
         ZIO.runtime
           .toManaged_
           .flatMap { implicit r: Runtime[R] =>
-            BlazeServerBuilder[RIO[R, *]](scala.concurrent.ExecutionContext.global)
-              .bindHttp(8080, "localhost")
+            EmberServerBuilder.default[RIO[R, *]]
               .withHttpApp(httpApp)
-              .resource
+              .build
               .toManagedZIO
           }
       }


### PR DESCRIPTION
- sbt syntax
- Downgrading interop-cats to a compatible http4s version
- Switching from BlazeServerBuilder to EmberServerBuilder